### PR TITLE
Add random reviewers to Compare-Page

### DIFF
--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -7,7 +7,7 @@ import styles from "./IconButton.module.scss";
 
 type Props = {
   Icon: Icon;
-  onClick: () => void;
+  onClick: React.MouseEventHandler<HTMLSpanElement>;
   isLoading: boolean;
   tooltipText?: string;
   className?: string;

--- a/src/components/RandomReviewerButton/RandomReviewerButton.module.scss
+++ b/src/components/RandomReviewerButton/RandomReviewerButton.module.scss
@@ -1,4 +1,3 @@
 .icon {
   display: inline-flex;
-  margin-right: 16px;
 }

--- a/src/components/RandomReviewerButton/RandomReviewerButton.tsx
+++ b/src/components/RandomReviewerButton/RandomReviewerButton.tsx
@@ -14,7 +14,8 @@ type Props = {
 export const RandomReviewerButton = ({ octokit, instanceConfig }: Props) => {
   const [isLoading, isLoadingSet] = useState(false);
 
-  const handleClick = () => {
+  const handleClick: React.MouseEventHandler<HTMLSpanElement> = (e) => {
+    e.preventDefault();
     void assignRandomReviewer(octokit, instanceConfig, isLoadingSet);
   };
 

--- a/src/content/handleRandomReviewer.tsx
+++ b/src/content/handleRandomReviewer.tsx
@@ -14,28 +14,36 @@ export const handleRandomReviewer = (
   const urlUiPr = isOnPrPage(instanceConfig);
   if (!urlUiPr) return;
 
-  const topRightSection = document.getElementsByClassName("tabnav-extra")[0];
-  if (!topRightSection) return;
-
-  createRandomReviewerButton(topRightSection, octokit, instanceConfig);
+  const detailsEl = document.getElementById("reviewers-select-menu");
+  createRandomReviewerButton(detailsEl, octokit, instanceConfig);
 };
 
 const createRandomReviewerButton = (
-  parent: Element,
+  detailsEl: Element | null,
   octokit: OctokitWithCache,
   instanceConfig: InstanceConfig,
 ) => {
-  if (parent.querySelector(`.${RANDOM_REVIEWER_BUTTON_CLASS}`)) return;
+  if (!detailsEl || !detailsEl.parentNode) return;
 
-  // make parent a flex container to align all children in it
-  if (parent instanceof HTMLElement)
-    parent.style.setProperty("display", "flex", "important");
+  if (detailsEl.parentNode?.querySelector(`.${RANDOM_REVIEWER_BUTTON_CLASS}`))
+    return;
 
-  const spanContainer = document.createElement("span");
-  spanContainer.classList.add(RANDOM_REVIEWER_BUTTON_CLASS);
-  parent.insertBefore(spanContainer, parent.firstChild);
+  const wrapperDiv = document.createElement("div");
+  wrapperDiv.style.cssText = `
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 1rem;
+  `;
 
-  const root = createRoot(spanContainer);
+  // move detailsEl inside the wrapperDiv
+  detailsEl.parentNode?.insertBefore(wrapperDiv, detailsEl);
+  wrapperDiv.appendChild(detailsEl);
+
+  const spanEl = document.createElement("span");
+  spanEl.classList.add(RANDOM_REVIEWER_BUTTON_CLASS);
+  wrapperDiv.appendChild(spanEl);
+
+  const root = createRoot(spanEl);
   root.render(
     <React.StrictMode>
       <RandomReviewerButton octokit={octokit} instanceConfig={instanceConfig} />

--- a/src/content_compare_page.tsx
+++ b/src/content_compare_page.tsx
@@ -1,8 +1,10 @@
+import { handleRandomReviewer } from "./content";
 import { addPrTitleFromJira } from "./content/addPrTitleFromJira";
 import { addDescriptionTemplate } from "./content/addDescriptionTemplate";
 import { isOnComparePage } from "./content/utils/comparePageUtils";
 import { getInstanceConfig } from "./getInstanceConfig";
 import { getSettings, InstanceConfig, Settings } from "./services";
+import { getOctoInstance } from "./services/getOctoInstance";
 
 getSettings({
   onSuccess: handleContentChange,
@@ -22,11 +24,16 @@ async function executeScripts(
   if (!isOnComparePage(instanceConfig)) return;
 
   try {
+    const octokit = getOctoInstance(instanceConfig);
+
     if (settings.features.descriptionTemplate) {
       addDescriptionTemplate(settings);
     }
     if (settings.features.prTitleFromJira) {
       await addPrTitleFromJira(settings);
+    }
+    if (instanceConfig.randomReviewers) {
+      handleRandomReviewer(octokit, instanceConfig);
     }
   } catch (err) {
     alert(


### PR DESCRIPTION
Damit wir den `RandomReviewersButton` einheitlich auf der PR-Page, als auch auf der "Comparing changes"-Page haben, habe ich ihn verschoben zu **Reviewers**:

<img width="341" height="109" alt="image" src="https://github.com/user-attachments/assets/36efb1a1-9b36-4f2c-a33c-4dfa0e877e90" />

Sieht zwar besser aus, aber wenn Reviewers re-rendert (Reviewer wurde hinzugefügt/entfernt), ist der Button weg und man muss die Page neu laden.

Technisches Problem: wir haben keinen fertigen PR, sondern nur Refs.

Angenommen, wir haben folgende Compare-Page mit URL: `<owner>/<repo>/compare/main...dummy/for-screenshots3`

Dann macht GitHub folgenden GET request:

`<owner>/<repo>/pull/new/review-requests/main...dummy%2Ffor-screenshots3`

Das ist soweit, wie auf der PR-Page.

Der POST-Request scheint aber Form-Data rauszuschicken:

<img width="899" height="396" alt="image" src="https://github.com/user-attachments/assets/b614590d-4c85-4c19-ba9c-da3fed125487" />

Und die Server-Response ist ein HTML:

<img width="1490" height="376" alt="image" src="https://github.com/user-attachments/assets/3c259081-9806-44d6-a84a-d09405cf0543" />


Whooooooot 🤯 

@lukegskw vielleicht hast du eine Idee 💡 